### PR TITLE
[actions] Create new GitHub actions: build, release and publish

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Jose Javier Merchante <jjmerchante@bitergia.com>
+Venu Vardhan Reddy Tekula <venu@chaoss.community>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# GrimoireLab GitHub actions
+
+## build
+
+Build a Python package using Poetry and store the package as an artifact for future jobs.
+
+See [build/action.yml](build/action.yml)
+
+### Inputs
+- `artifact-name`: artifact name for future jobs (default: artifact).
+- `artifact-path`: directory that contains the package to store for future jobs (default: dist).
+
+### Usage
+
+```yaml
+steps:
+  - uses: chaoss/grimoirelab-github-actions/build@master
+    with:
+      artifact-name: grimoire-dist
+      artifact-path: dist
+```

--- a/README.md
+++ b/README.md
@@ -19,3 +19,23 @@ steps:
       artifact-name: grimoire-dist
       artifact-path: dist
 ```
+
+
+## release
+
+Create a new GitHub release for the repository. 
+
+It uses the tag that triggered the workflow and the notes available under `releases/<tag>.md`.
+
+See [release/action.yml](release/action.yml)
+
+### Inputs
+- `github-token`: token provided by actions, read the usage.
+
+### Usage
+```yaml
+steps:
+  - uses: chaoss/grimoirelab-github-actions/release@master
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/README.md
+++ b/README.md
@@ -39,3 +39,29 @@ steps:
     with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+
+## publish
+
+Publish a Python package to PyPI using Poetry. 
+
+The package should be already built, you can use `grimoirelab-github-actions/build`.
+
+
+See [publish/action.yml](publish/action.yml)
+
+### Inputs
+- `artifact-name`: artifact name from previous jobs (default: artifact).
+- `artifact-path`: directory that contains the package to publish (default: dist).
+- `pypi-api-token`: token to publish the package in PyPI (required).
+
+
+### Usage
+```yaml
+steps:
+  - uses: chaoss/grimoirelab-github-actions/publish@master
+    with:
+      artifact-name: grimoire-dist
+      artifact-path: dist
+      pypi-api-token: ${{ secrets.PYPI_API_TOKEN }}
+```

--- a/build/action.yml
+++ b/build/action.yml
@@ -1,0 +1,34 @@
+name: 'Build Python package'
+description: 'Build a Python package and store the results'
+inputs:
+  artifact-name:
+    default: "artifact"
+  artifact-path:
+    default: "dist"
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Build distributions
+      run: |
+        poetry build
+      shell: bash
+
+    - name: Upload distribution artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifact-path }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -1,0 +1,43 @@
+name: 'Publish Python package'
+description: 'Publish a Python package already built using Poetry.'
+inputs:
+  artifact-name:
+    default: "artifact"
+  artifact-path:
+    default: "dist"
+  pypi-api-token:
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Download distribution artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifact-path }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Configure pypi credentials
+      env:
+        PYPI_API_TOKEN: ${{ inputs.pypi-api-token }}
+      run: |
+        poetry config http-basic.pypi __token__ "$PYPI_API_TOKEN"
+      shell: bash
+
+    - name: Publish release to pypi
+      run: |
+        poetry publish
+      shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -1,0 +1,25 @@
+name: 'Create a new release'
+description: 'Create a new release using the release notes for the tag.'
+inputs:
+  github-token:
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Get release tag
+      id: tag
+      run: |
+        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+      shell: bash
+
+    - name: Create release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        tag_name: ${{ steps.tag.outputs.tag }}
+        release_name: ${{ steps.tag.outputs.tag }}
+        body_path: ./releases/${{ steps.tag.outputs.tag }}.md


### PR DESCRIPTION
This pull request includes the following GitHub actions grouped by directory:
- build: build a Python package using Poetry and store the package as an artifact for future jobs.
- release: create a new GitHub release for the repository using the tag that triggered the workflow
- publish: publish a Python package to PyPI using Poetry

Related to https://github.com/chaoss/grimoirelab/issues/462
