### PR TITLE
Build wheel packages using Poeblix

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -16,15 +16,18 @@ runs:
       with:
         python-version: '3.x'
 
-    - name: Install poetry
+    - name: Install poetry and add plugins
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
         echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+        poetry self update --preview
+        poetry self add poeblix
       shell: bash
 
     - name: Build distributions
       run: |
-        poetry build
+        poetry blixbuild
+        poetry build -f sdist
       shell: bash
 
     - name: Upload distribution artifacts


### PR DESCRIPTION
This PR uses Poeblix for creating the packages. It allows to include `poetry.lock `dependencies in the wheel package.

Here is an example of a generated package: https://github.com/jjmerchante2/grimoirelab-sirmordred/actions/runs/2655625619. In that workflow run, I omitted the tests.