### PR TITLE
[build] Update build command to use only .lock dependencies

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -20,13 +20,12 @@ runs:
       run: |
         curl -sSL https://install.python-poetry.org | python3 -
         echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
-        poetry self update --preview
         poetry self add poeblix
       shell: bash
 
     - name: Build distributions
       run: |
-        poetry blixbuild
+        poetry blixbuild --only-lock
         poetry build -f sdist
       shell: bash
 


### PR DESCRIPTION
This PR includes a new option for Poeblix to build the package using only the lock dependencies.

This PR also removes the preview installation of Poetry because 1.2 is now stable.
