### PR TITLE
[actions] Update release action and include SHA version of the action used

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -9,10 +9,10 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: '3.x'
 
@@ -30,7 +30,7 @@ runs:
       shell: bash
 
     - name: Upload distribution artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -11,16 +11,16 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
 
     - name: Download distribution artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: '3.x'
 

--- a/release/action.yml
+++ b/release/action.yml
@@ -7,19 +7,17 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
 
     - name: Get release tag
       id: tag
       run: |
-        echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
+        echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Create release
-      uses: actions/create-release@v1
+      run: |
+        gh release create ${{ steps.tag.outputs.tag }} -t ${{ steps.tag.outputs.tag }} -F ./releases/${{ steps.tag.outputs.tag }}.md
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-      with:
-        tag_name: ${{ steps.tag.outputs.tag }}
-        release_name: ${{ steps.tag.outputs.tag }}
-        body_path: ./releases/${{ steps.tag.outputs.tag }}.md
+      shell: bash


### PR DESCRIPTION
This commit updates the version number of the actions being used. Now they will use the commit SHA of a released action version because it is the best for stability and security.

It also updates the way the release is generated because actions/create-release is deprecated.
