### PR TITLE
Pin Poetry version to 1.5.1

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Install poetry and add plugins
       run: |
-        curl -sSL https://install.python-poetry.org | python3 -
+        curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.5.1 python3 -
         echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
         poetry self add poeblix
       shell: bash


### PR DESCRIPTION
This PR pins the version of poetry to 1.5.1 because `poeblix` 0.9 is not compatible with poetry >=1.6.0.