### PR TITLE
[build] Allow to decide if dependencies are pinned or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ See [build/action.yml](build/action.yml)
 ### Inputs
 - `artifact-name`: artifact name for future jobs (default: artifact).
 - `artifact-path`: directory that contains the package to store for future jobs (default: dist).
+- `skip-checkout`: set to 'yes' to avoid checking out the repository (default: 'no').
+- `pin-dependencies`: set to 'yes' to pin `poetry.lock` dependencies (default: 'no').
 
 ### Usage
 
@@ -18,6 +20,8 @@ steps:
     with:
       artifact-name: grimoire-dist
       artifact-path: dist
+      skip-checkout: yes
+      pin-dependencies: yes
 ```
 
 

--- a/build/action.yml
+++ b/build/action.yml
@@ -8,6 +8,9 @@ inputs:
   skip-checkout:
     description: "Set to 'yes' to avoid checking out the repository. Default 'no'."
     default: "no"
+  pin-dependencies:
+    description: "Set to 'yes' to pin 'poetry.lock' dependencies. Default 'no'."
+    default: "no"
 
 runs:
   using: 'composite'
@@ -28,10 +31,15 @@ runs:
         poetry self add poeblix
       shell: bash
 
-    - name: Build distributions
+    - name: Build distributions.
       run: |
-        poetry blixbuild --only-lock
-        poetry build -f sdist
+        if [ ${{ inputs.pin-dependencies }} == 'yes' ]
+        then
+          poetry blixbuild --only-lock
+          poetry build -f sdist
+        else
+          poetry build
+        fi
       shell: bash
 
     - name: Upload distribution artifacts


### PR DESCRIPTION
This PR allows building packages with dependencies pinned using `poeblix` or not pinned using the default behavior of `poetry build`.