### PR TITLE
Avoid timeouts while publishing a package on Pypi

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -38,6 +38,8 @@ runs:
       shell: bash
 
     - name: Publish release to pypi
+      env:
+        POETRY_REQUESTS_TIMEOUT: 120
       run: |
         poetry publish
       shell: bash


### PR DESCRIPTION
Publishing packages on PyPI using GitHub actions can take longer than expected. Poetry has a timeout of 15 seconds to check for new activity on the network but on GitHub actions sometimes that's not enough. This error was reported on https://github.com/python-poetry/poetry/issues/6009 and it's fixed using the env variable POETRY_REQUESTS_TIMEOUT. We set this variable to 120 seconds that should be more that enough for PyPI to finish the work.