### PR TITLE
[build] Define custom Python version for package builds

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -11,6 +11,9 @@ inputs:
   pin-dependencies:
     description: "Set to 'yes' to pin 'poetry.lock' dependencies. Default 'no'."
     default: "no"
+  python-version:
+    description: "Python version to use. Default '3.x'."
+    default: "3.x"
 
 runs:
   using: 'composite'
@@ -22,7 +25,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.x'
+        python-version: ${{ inputs.python-version }}
 
     - name: Install poetry and add plugins
       run: |


### PR DESCRIPTION
Add an input to the build workflow to allow specifying a custom Python version when creating the packages.