### PR TITLE
Specify python version for Poetry installation

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -31,10 +31,10 @@ runs:
       run: |
         if [ ${{ inputs.pin-dependencies }} == 'yes' ]
         then
-          pipx install poetry==1.5.1
+          pipx install poetry==1.5.1 --python $(which python)
           poetry self add poeblix
         else
-          pipx install poetry
+          pipx install poetry --python $(which python)
         fi
       shell: bash
 


### PR DESCRIPTION
This change ensures that the correct Python version is used when installing Poetry. It helps avoid issues that may arise from using a different Python version than expected